### PR TITLE
Fixed DecodeTTL attribute. Removed TTLString padding. 

### DIFF
--- a/include/stunlib.h
+++ b/include/stunlib.h
@@ -97,7 +97,6 @@ extern "C" {
 
 /*STUNTrace Attributes (Experimental) */
 #define STUN_ATTR_TTL                0x8055
-#define STUN_ATTR_TTLString          0x8056
 
 /* STUN attributes (TURN extensions) */
 #define STUN_ATTR_ChannelNumber       0x000c
@@ -529,9 +528,6 @@ typedef struct
   bool       hasTTL;
   StunAtrTTL ttl;
 
-  bool          hasTTLString;
-  StunAtrString TTLString;
-
   /*After Integrity attr*/
   bool                 hasNetworkStatus;
   StunAtrNetworkStatus networkStatus;
@@ -889,11 +885,6 @@ stunlib_calculateFingerprint(const uint8_t* buf,
 bool
 stunlib_checkFingerPrint(const uint8_t* buf,
                          uint32_t       fpOffset);
-
-bool
-stunlib_addTTLString(StunMessage* stunMsg,
-                     const char*  TTLString,
-                     char         padChar);
 
 
 /* Concat  username+realm+passwd into string "<username>:<realm>:<password>"

--- a/src/stunclient.c
+++ b/src/stunclient.c
@@ -1243,8 +1243,19 @@ static void
 CancelRetryTimeoutHandler(STUN_TRANSACTION_DATA* trans)
 {
   STUN_CLIENT_DATA* client = trans->client;
+  uint32_t max;
 
-  if ( (trans->retransmits < STUNCLIENT_MAX_RETRANSMITS)
+  if (trans->stunBindReq.stuntrace)
+  {
+    max = STUNTRACE_MAX_RETRANSMITS;
+  }
+  else
+  {
+    max = STUNCLIENT_MAX_RETRANSMITS;
+  }
+
+
+  if ( (trans->retransmits < max)
        && (stunTimeoutList[trans->retransmits] != 0) ) /* can be 0 terminated if
                                                         * using fewer
                                                         * retransmits

--- a/src/stunclient.c
+++ b/src/stunclient.c
@@ -194,19 +194,8 @@ BuildStunBindReq(STUN_TRANSACTION_DATA* trans,
   /* ttl */
   if (trans->stunBindReq.ttl > 0)
   {
-    char ttlString[200];
-    char iTTL[5] = "0000\0";
     stunReqMsg->hasTTL  = true;
     stunReqMsg->ttl.ttl = trans->stunBindReq.ttl;
-
-    sprintf(iTTL, "%.4i", trans->stunBindReq.ttl);
-    ttlString[0] = '\0';
-    for (int i = 0; i < trans->stunBindReq.ttl; i++)
-    {
-      strncat(ttlString,iTTL, 4);
-    }
-
-    stunlib_addTTLString(stunReqMsg, ttlString, 'a');
   }
 
 

--- a/src/stunlib.c
+++ b/src/stunlib.c
@@ -1439,7 +1439,7 @@ stunDecodeUnknownAtr(StunAtrUnknown* pUnk,
                      int             atrLen)
 {
   uint32_t padLen = calcPadLen(atrLen, 4);
-  int i;
+  int      i;
   if (*nBufLen < atrLen)
   {
     return false;
@@ -1449,8 +1449,8 @@ stunDecodeUnknownAtr(StunAtrUnknown* pUnk,
     read_16(pBuf, &pUnk->attrType[i]);
   }
   pUnk->numAttributes = i;
-  *nBufLen           -= ( atrLen + padLen );
-  *pBuf           += padLen;
+  *nBufLen           -= (atrLen + padLen);
+  *pBuf              += padLen;
   if ( i < (atrLen / 2) )
   {
     *nBufLen -= (atrLen - 2 * i);
@@ -2111,9 +2111,12 @@ stunlib_DecodeMessage(const uint8_t*  buf,
     }
     if ( !stunDecodeAttributeHead(&sAtr, &pCurrPtr, &restlen) )
     {
+      if (stream)
+      {
         printError(stream,
-                 "stunlib_DecodeMessage: Failed to parse Attribute head (%d)\n",
-                 restlen);
+                   "stunlib_DecodeMessage: Failed to parse Attribute head (%d)\n",
+                   restlen);
+      }
       return false;
     }
     if (stream)
@@ -3243,7 +3246,10 @@ stunlib_encodeMessage(StunMessage*   message,
                                    &pCurrPtr,
                                    &restlen) )
     {
-      printError(stream, "Faild to add CRC Fingerprint\n");
+      if (stream)
+      {
+        printError(stream, "Faild to add CRC Fingerprint\n");
+      }
     }
     else
     {
@@ -3253,7 +3259,7 @@ stunlib_encodeMessage(StunMessage*   message,
   }
   if (stream)
   {
-      printError(stream, "STUN_encode, messages to encode: \n");
+        printError(stream, "STUN_encode, messages to encode: \n");
     stun_printMessage(stream, message);
     printError(stream, "STUN_encode, buffer encoded: \n");
     stunlib_printBuffer(stream, (uint8_t*)buf, msglen, "STUN");

--- a/src/stunlib.c
+++ b/src/stunlib.c
@@ -1577,7 +1577,7 @@ stunDecodeTTL(StunAtrTTL*     ttl,
   read_8(pBuf, &ttl->pad_8);
   read_16(pBuf, &ttl->pad_16);
 
-  *nBufLen -= 8;
+  *nBufLen -= 4;
   return true;
 }
 
@@ -2387,17 +2387,6 @@ stunlib_DecodeMessage(const uint8_t*  buf,
       message->hasTTL = true;
       break;
 
-    case STUN_ATTR_TTLString:
-      if ( !stunDecodeStringAtr(&message->TTLString,
-                                &pCurrPtr,
-                                &restlen,
-                                sAtr.length) )
-      {
-        return false;
-      }
-      message->hasTTLString = true;
-      break;
-
     case STUN_ATTR_StreamType:
       if ( !stunDecodeStreamType(&message->streamType,
                                  &pCurrPtr,
@@ -3095,18 +3084,6 @@ stunlib_encodeMessage(StunMessage*   message,
     return 0;
   }
 
-  if ( message->hasTTLString && !stunEncodeStringAtr(&message->TTLString,
-                                                     STUN_ATTR_TTLString,
-                                                     &pCurrPtr,
-                                                     &restlen) )
-  {
-    if (stream)
-    {
-        printError(stream, "Invalid TTLString\n");
-    }
-    return 0;
-  }
-
   if ( message->hasNetworkStatusResp &&
        !stunEncodeNetworkStatus(&message->networkStatusResp,
                                 &pCurrPtr,
@@ -3308,22 +3285,6 @@ stunlib_addUserName(StunMessage* stunMsg,
   stunSetString(&stunMsg->username, userName, padChar);
   return true;
 }
-
-bool
-stunlib_addTTLString(StunMessage* stunMsg,
-                     const char*  TTLString,
-                     char         padChar)
-{
-  if (strlen(TTLString) > STUN_MSG_MAX_USERNAME_LENGTH)
-  {
-    return false;
-  }
-
-  stunMsg->hasTTLString = true;
-  stunSetString(&stunMsg->TTLString, TTLString, padChar);
-  return true;
-}
-
 
 bool
 stunlib_addRealm(StunMessage* stunMsg,

--- a/test/stuntrace_test.c
+++ b/test/stuntrace_test.c
@@ -148,8 +148,9 @@ CTEST(stuntrace, run_IPv4)
                                  1,
                                  StunTraceCallBack,
                                  sendPacket);
+
   /* First alive probe */
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
   ASSERT_TRUE(LastTTL == 40);
 
 
@@ -218,7 +219,7 @@ CTEST(stuntrace, run_IPv4_unhandled_ICMP)
                                  StunTraceCallBack,
                                  sendPacket);
   /* First alive probe */
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
   ASSERT_TRUE(LastTTL == 40);
 
 
@@ -285,7 +286,7 @@ CTEST(stuntrace, recurring_IPv4)
                                  2,
                                  StunTraceCallBack,
                                  sendPacket);
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
   ASSERT_TRUE(LastTTL == 40);
 
   StunClient_HandleICMP(clientData,
@@ -362,7 +363,7 @@ CTEST(stuntrace, no_answer_IPv4)
                                  1,
                                  StunTraceCallBack,
                                  sendPacket);
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
   StunClient_HandleICMP(clientData,
                         (struct sockaddr*)&remoteAddr,
                         3);
@@ -440,7 +441,7 @@ CTEST(stuntrace, no_answer_recurring_IPv4)
                                  2,
                                  StunTraceCallBack,
                                  sendPacket);
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
 
   StunClient_HandleICMP(clientData,
                         (struct sockaddr*)&remoteAddr,
@@ -549,7 +550,7 @@ CTEST(stuntrace, run_IPv4_Stunresp)
                                  StunTraceCallBack,
                                  sendPacket);
   /* First alive probe */
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
   ASSERT_TRUE(LastTTL == 40);
   StunMessage m;
   memset( &m, 0, sizeof(m) );
@@ -693,7 +694,7 @@ CTEST(stuntrace, run_IPv4_Stunresp_end)
                                  StunTraceCallBack,
                                  sendPacket);
   /* First alive probe */
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
   ASSERT_TRUE(LastTTL == 40);
   StunMessage m;
   memset( &m, 0, sizeof(m) );
@@ -759,7 +760,7 @@ CTEST(stuntrace, run_IPv4_Stunresp_max_ttl)
                                  StunTraceCallBack,
                                  sendPacket);
   /* First alive probe */
-  ASSERT_TRUE(len == 224);
+  ASSERT_TRUE(len != 0);
   ASSERT_TRUE(LastTTL == 40);
   StunMessage m;
   memset( &m, 0, sizeof(m) );

--- a/test/testvector_test.c
+++ b/test/testvector_test.c
@@ -1091,3 +1091,37 @@ CTEST(testvector, stun_msg_len)
 {
   ASSERT_TRUE(stunlib_StunMsgLen(unknwn) == 88);
 }
+
+CTEST(testvector, encode_decode_ttl)
+{
+  StunMessage   stunMsg;
+  unsigned char stunBuf[120];
+
+  for (int ttl = 1; ttl < 20; ttl++)
+  {
+    memset( &stunMsg, 0, sizeof(StunMessage) );
+    stunMsg.msgHdr.msgType = STUN_MSG_BindRequestMsg;
+    memcpy(&stunMsg.msgHdr.id.octet,&idOctet,12);
+
+    ASSERT_TRUE( stunlib_addUserName(&stunMsg, username, '\x20') );
+    ASSERT_TRUE( stunlib_addSoftware(&stunMsg, software, '\x20') );
+    stunMsg.hasTTL  = true;
+    stunMsg.ttl.ttl = ttl;
+    ASSERT_TRUE( stunlib_encodeMessage(&stunMsg,
+                                       stunBuf,
+                                       120,
+                                       (unsigned char*)password,
+                                       strlen(password),
+                                       NULL) );
+
+    memset(&stunMsg, 0, sizeof stunMsg);
+
+    ASSERT_TRUE( stunlib_DecodeMessage(stunBuf,
+                                       120,
+                                       &stunMsg,
+                                       NULL,
+                                       NULL) );
+    ASSERT_TRUE(stunMsg.hasTTL);
+    ASSERT_TRUE(stunMsg.ttl.ttl == ttl);
+  }
+}

--- a/test/turnclient_test.c
+++ b/test/turnclient_test.c
@@ -1360,7 +1360,6 @@ CTEST(turnclient, Allocated_CreatePermissionReq_no_IP)
 {
   struct sockaddr_storage  peerIp[6];
   struct sockaddr_storage* p_peerIp[6];
-  int                      ctx;
   uint32_t                 i;
 
   for (i = 0; i < sizeof(peerIp) / sizeof(peerIp[0]); i++)
@@ -1370,7 +1369,7 @@ CTEST(turnclient, Allocated_CreatePermissionReq_no_IP)
   }
   p_peerIp[4] = NULL;
 
-  ctx = GotoAllocatedState(12);
+  GotoAllocatedState(12);
   ASSERT_FALSE( TurnClient_StartCreatePermissionReq(pInst,
                                                     sizeof(peerIp) /
                                                     sizeof(peerIp[0]),

--- a/test/turnclient_test.c
+++ b/test/turnclient_test.c
@@ -497,19 +497,19 @@ CTEST(turnclient, WaitAllocRespNotAut_Timeout)
 
 CTEST(turnclient, startAllocation_NULL)
 {
-  ASSERT_FALSE (TurnClient_StartAllocateTransaction(NULL,
-                                             50,
-                                             NULL,
-                                             "test",
-                                             NULL,
-                                             NULL,
-                                             "pem",
-                                             "pem",
-                                             AF_INET6,
-                                             SendRawStun,
-                                             TurnStatusCallBack,
-                                             false,
-                                             0));
+  ASSERT_FALSE( TurnClient_StartAllocateTransaction(NULL,
+                                                    50,
+                                                    NULL,
+                                                    "test",
+                                                    NULL,
+                                                    NULL,
+                                                    "pem",
+                                                    "pem",
+                                                    AF_INET6,
+                                                    SendRawStun,
+                                                    TurnStatusCallBack,
+                                                    false,
+                                                    0) );
 
 }
 CTEST(tunrclient, resultToString)
@@ -1147,7 +1147,45 @@ CTEST(turnclient, Allocated_ChanBindReqOk_IPv6)
 
 }
 
+CTEST(turnclient, Allocated_ChanBindReq_fail_num)
+{
+  struct sockaddr_storage peerIp;
+  int                     ctx;
+  sockaddr_initFromString( (struct sockaddr*)&peerIp,"192.168.5.22:1234" );
 
+  ctx = GotoAllocatedState(12);
+  ASSERT_FALSE( TurnClient_StartChannelBindReq(pInst, 0x3001,
+                                              (struct sockaddr*)&peerIp) );
+
+  TurnClient_HandleTick(pInst);
+  Sim_ChanBindOrPermissionResp(ctx, STUN_MSG_ChannelBindResponseMsg, 0, 0);
+  TurnClient_HandleTick(pInst);
+  ASSERT_FALSE(turnResult == TurnResult_ChanBindOk);
+
+  TurnClient_Deallocate(pInst);
+  Sim_RefreshResp(ctx);
+  ASSERT_TRUE(turnResult == TurnResult_RelayReleaseComplete);
+}
+
+CTEST(turnclient, Allocated_ChanBindReq_fail_ip)
+{
+  struct sockaddr_storage peerIp;
+  int                     ctx;
+  sockaddr_initFromString( (struct sockaddr*)&peerIp,"192.168.5.22:1234" );
+
+  ctx = GotoAllocatedState(12);
+  ASSERT_FALSE( TurnClient_StartChannelBindReq(pInst, 0x4001,
+                                              (struct sockaddr*)NULL) );
+
+  TurnClient_HandleTick(pInst);
+  Sim_ChanBindOrPermissionResp(ctx, STUN_MSG_ChannelBindResponseMsg, 0, 0);
+  TurnClient_HandleTick(pInst);
+  ASSERT_FALSE(turnResult == TurnResult_ChanBindOk);
+
+  TurnClient_Deallocate(pInst);
+  Sim_RefreshResp(ctx);
+  ASSERT_TRUE(turnResult == TurnResult_RelayReleaseComplete);
+}
 
 CTEST(turnclient, Allocated_ChanBindRefresh)
 {
@@ -1976,8 +2014,8 @@ CTEST(turnclient,recievepacket_bound_IPv6)
 
   unsigned char buf[] =
     "123456789abcdef123456789Some data to be sendt. Here and there.\0";
-    sockaddr_initFromString( (struct sockaddr*)&addr,
-                             "[2a02:fe0:c410:cb31:e4d:e93f:fecb:bf6b]:1234\0" );
+  sockaddr_initFromString( (struct sockaddr*)&addr,
+                           "[2a02:fe0:c410:cb31:e4d:e93f:fecb:bf6b]:1234\0" );
 
 
   ctx = GotoAllocatedState(12);
@@ -2134,7 +2172,7 @@ CTEST(turnclient, recievepacket_un_bound_IPv6)
                                      sizeof buf,
                                      sizeof data,
                                      (struct sockaddr*)&addr);
-  ASSERT_TRUE(len == 88);
+  ASSERT_TRUE( len == 88);
 
   ASSERT_TRUE( TurnClient_ReceivePacket(pInst,
                                         buf,

--- a/test/turnclient_test.c
+++ b/test/turnclient_test.c
@@ -520,6 +520,44 @@ CTEST(turnclient, startAllocation_NULL)
                                                     0) );
 
 }
+
+
+CTEST(turnclient, startAllocation_even)
+{
+  ASSERT_TRUE( TurnClient_StartAllocateTransaction(&pInst,
+                                                    50,
+                                                    NULL,
+                                                    "test",
+                                                    NULL,
+                                                    NULL,
+                                                    "pem",
+                                                    "pem",
+                                                    AF_INET6,
+                                                    SendRawStun,
+                                                    TurnStatusCallBack,
+                                                    true,
+                                                    0) );
+
+}
+
+CTEST(turnclient, startAllocation_odd)
+{
+  ASSERT_TRUE( TurnClient_StartAllocateTransaction(&pInst,
+                                                    50,
+                                                    NULL,
+                                                    "test",
+                                                    NULL,
+                                                    NULL,
+                                                    "pem",
+                                                    "pem",
+                                                    AF_INET6,
+                                                    SendRawStun,
+                                                    TurnStatusCallBack,
+                                                    true,
+                                                    45678) );
+
+}
+
 CTEST(tunrclient, resultToString)
 {
   ASSERT_TRUE(strcmp(TurnResultToStr(TurnResult_AllocOk),
@@ -588,6 +626,7 @@ CTEST(turnclient, WaitAllocRespNotAut_AllocRspOk)
   SimAllocResp(ctx, true, true, true, runningAsIPv6, true, false);
   ASSERT_TRUE(turnResult == TurnResult_AllocOk);
   ASSERT_FALSE( TurnClient_hasBeenRedirected(pInst) );
+  ASSERT_FALSE( TurnClient_hasBeenRedirected(NULL ) );
 
   TurnClient_Deallocate(pInst);
   Sim_RefreshResp(ctx);
@@ -1307,6 +1346,7 @@ CTEST(turnclient, Allocated_CreatePermissionReqOk)
   struct sockaddr_storage* p_peerIp[6];
   int                      ctx;
   uint32_t                 i;
+  TurnStats_T             stats;
 
   for (i = 0; i < sizeof(peerIp) / sizeof(peerIp[0]); i++)
   {
@@ -1322,6 +1362,14 @@ CTEST(turnclient, Allocated_CreatePermissionReqOk)
   Sim_ChanBindOrPermissionResp(ctx, STUN_MSG_CreatePermissionResponseMsg, 0, 0);
   TurnClient_HandleTick(pInst);
   ASSERT_TRUE(turnResult == TurnResult_CreatePermissionOk);
+
+  TurnClientGetStats(pInst,
+                     &stats);
+  ASSERT_TRUE(stats.Retransmits == 0);
+  ASSERT_TRUE(stats.Failures == 0);
+  ASSERT_TRUE(stats.numberOfPeers == 6);
+
+
   TurnClient_Deallocate(pInst);
   Sim_RefreshResp(ctx);
   ASSERT_TRUE(turnResult == TurnResult_RelayReleaseComplete);

--- a/test/turnclient_test.c
+++ b/test/turnclient_test.c
@@ -579,6 +579,7 @@ CTEST(turnclient, WaitAllocRespNotAut_AllocRspOk)
   TurnClient_HandleTick(pInst);
   SimAllocResp(ctx, true, true, true, runningAsIPv6, true);
   ASSERT_TRUE(turnResult == TurnResult_AllocOk);
+  ASSERT_FALSE( TurnClient_hasBeenRedirected(pInst) );
 
   TurnClient_Deallocate(pInst);
   Sim_RefreshResp(ctx);
@@ -593,6 +594,7 @@ CTEST(turnclient, WaitAllocRespNotAut_AllocRspOk_IPv6)
   TurnClient_HandleTick(pInst);
   SimAllocResp(ctx, true, true, true, runningAsIPv6, true);
   ASSERT_TRUE(turnResult == TurnResult_AllocOk);
+  ASSERT_FALSE( TurnClient_hasBeenRedirected(pInst) );
 
   TurnClient_Deallocate(pInst);
   Sim_RefreshResp(ctx);

--- a/test/turnclient_test.c
+++ b/test/turnclient_test.c
@@ -1331,6 +1331,26 @@ CTEST(turnclient, Allocated_CreatePermissionReqOk_IPv6)
   ASSERT_TRUE(turnResult == TurnResult_RelayReleaseComplete);
 }
 
+CTEST(turnclient, Allocated_CreatePermissionReq_no_IP)
+{
+  struct sockaddr_storage  peerIp[6];
+  struct sockaddr_storage* p_peerIp[6];
+  int                      ctx;
+  uint32_t                 i;
+
+  for (i = 0; i < sizeof(peerIp) / sizeof(peerIp[0]); i++)
+  {
+    sockaddr_initFromString( (struct sockaddr*)&peerIp[i],"192.168.5.22:1234" );
+    p_peerIp[i] = &peerIp[i];
+  }
+  p_peerIp[4] = NULL;
+
+  ctx = GotoAllocatedState(12);
+  ASSERT_FALSE( TurnClient_StartCreatePermissionReq(pInst,
+                                      sizeof(peerIp) / sizeof(peerIp[0]),
+                                      (const struct sockaddr**)p_peerIp) );
+}
+
 CTEST(turnclient, Allocated_CreatePermissionRefresh)
 {
   struct sockaddr_storage  peerIp[6];

--- a/test/turnclient_test.c
+++ b/test/turnclient_test.c
@@ -494,6 +494,24 @@ CTEST(turnclient, WaitAllocRespNotAut_Timeout)
 
 }
 
+
+CTEST(turnclient, startAllocation_NULL)
+{
+  ASSERT_FALSE (TurnClient_StartAllocateTransaction(NULL,
+                                             50,
+                                             NULL,
+                                             "test",
+                                             NULL,
+                                             NULL,
+                                             "pem",
+                                             "pem",
+                                             AF_INET6,
+                                             SendRawStun,
+                                             TurnStatusCallBack,
+                                             false,
+                                             0));
+
+}
 CTEST(tunrclient, resultToString)
 {
   ASSERT_TRUE(strcmp(TurnResultToStr(TurnResult_AllocOk),


### PR DESCRIPTION
No longer need for STUN length padding. Information not available on some OSes when dealing with the ICMP response. 
