### PR TITLE
Externalise functions which provide hmac/md5/crc32 functions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,7 @@ build
 *.pc
 .DS_Store
 
+# CLion
+.idea
 
 

--- a/include/stun_crypto.h
+++ b/include/stun_crypto.h
@@ -1,0 +1,22 @@
+/*
+ *  See license file
+ */
+
+#include <stdlib.h>
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+unsigned char* stunlib_util_md5(const void* data, size_t len, unsigned char* md);
+
+void stunlib_util_sha1_hmac(const void* key, size_t keyLength, const void* data, size_t dataLength, void* macOut, unsigned int* macLength);
+
+void stunlib_util_random(void* buffer, size_t size);
+
+uint32_t stunlib_util_crc32(long crc, const uint8_t* buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set ( stunlib_srcs
       stunlib.c
       turnclient.c
       stuntrace.c
+      stun_crypto.c
 )
 
 set (ADDITIONAL_LIBS "")
@@ -24,10 +25,11 @@ install ( TARGETS stunlib
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
-find_package( ZLIB REQUIRED )
+find_package( ZLIB )
 if ( ZLIB_FOUND )
     include_directories( ${ZLIB_INCLUDE_DIRS} )
     list(APPEND ADDITIONAL_LIBS ${ZLIB_LIBRARIES})
+    add_definitions(-DSTUNLIB_USE_ZLIB)
 endif( ZLIB_FOUND )
 
 
@@ -35,11 +37,13 @@ find_package( OpenSSL )
 if( OPENSSL_FOUND )
   include_directories( ${OPENSSL_INCLUDE_DIR} )
   list(APPEND ADDITIONAL_LIBS ${OPENSSL_LIBRARIES})
+  add_definitions(-DSTUNLIB_USE_OPENSSL)
 endif( OPENSSL_FOUND )
 
 # Todo fix propper library discovery.
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
    list(APPEND ADDITIONAL_LIBS "bsd")
+   add_definitions(-DSTUNLIB_USE_BSD)
 endif()
 
 target_link_libraries ( stunlib PRIVATE sockaddrutil

--- a/src/stun_crypto.c
+++ b/src/stun_crypto.c
@@ -1,0 +1,60 @@
+/*
+ *  See license file
+ */
+
+#include "stun_crypto.h"
+
+#if defined(STUNLIB_USE_OPENSSL)
+#  include <openssl/md5.h>
+#  include <openssl/evp.h>
+#  include <openssl/hmac.h>
+
+unsigned char* stunlib_util_md5(const void *data, size_t len, unsigned char *md) {
+    return MD5( (uint8_t*)data, len, md );
+}
+
+void stunlib_util_sha1_hmac(const void *key, size_t keyLength, const void *data, size_t dataLength, void *macOut, unsigned int* macLength) {
+    HMAC(EVP_sha1(),
+         key,
+         keyLength,
+         data,
+         dataLength,
+         macOut, macLength);
+}
+
+#elif defined(__APPLE__)
+#  define COMMON_DIGEST_FOR_OPENSSL
+#  include <CommonCrypto/CommonDigest.h>
+#  include <CommonCrypto/CommonHMAC.h>
+
+unsigned char* stunlib_util_md5(const void *data, size_t len, unsigned char *md) {
+    return CC_MD5((uint8_t*)data, (CC_LONG) len, md);
+}
+
+void stunlib_util_sha1_hmac(const void *key,
+                            size_t keyLength,
+                            const void *data,
+                            size_t dataLength,
+                            void *macOut,
+                            __attribute__((unused)) unsigned int* macLength) {
+    CCHmac(kCCHmacAlgSHA1, key, keyLength, data, dataLength, macOut);
+}
+
+#endif // defined(__APPLE__)
+
+#if defined(STUNLIB_USE_BSD)
+#  include <bsd/stdlib.h>
+#endif
+
+#if defined(STUNLIB_USE_BSD) || defined(__APPLE__)
+void stunlib_util_random(void* buffer, size_t size) {
+    arc4random_buf(buffer, size);
+}
+#endif
+
+#if defined(STUNLIB_USE_ZLIB)
+#include <zlib.h>
+uint32_t stunlib_util_crc32(long crc, const uint8_t* buf, size_t len) {
+    return crc32(crc, buf, len);
+}
+#endif


### PR DESCRIPTION
into a separate set of utils.

This allows us to provide custom implementation of these functions if libz or openssl is unavailable (i.e. embedded)