### PR TITLE
Config customisation

### DIFF
--- a/include/stun_intern.h
+++ b/include/stun_intern.h
@@ -140,7 +140,7 @@ typedef struct
 struct STUN_CLIENT_DATA
 {
   void*                 userCtx;
-  STUN_TRANSACTION_DATA data [MAX_STUN_TRANSACTIONS];
+  STUN_TRANSACTION_DATA data [STUN_MAX_TRANSACTIONS];
 
 
   /*duplicated for logging on unknown transactions etc.*/

--- a/include/stunclient.h
+++ b/include/stunclient.h
@@ -16,10 +16,6 @@ extern "C" {
 #include <stdbool.h>
 #endif
 
-#define MAX_STUN_TRANSACTIONS  60
-#define SoftwareVersionStr "Cisco"
-
-
 /* forward declarations */
 struct STUN_CLIENT_DATA;
 typedef struct STUN_CLIENT_DATA STUN_CLIENT_DATA;

--- a/include/stunlib.h
+++ b/include/stunlib.h
@@ -29,6 +29,11 @@ extern "C" {
 #define min(a, b) ( ( (a) < (b) ) ? (a) : (b) )
 #endif
 
+#ifdef STUNLIB_CUSTOM_CONFIG
+#include STUNLIB_CUSTOM_CONFIG
+#else
+#include "stunlib_config.h"
+#endif
 
 /*** STUN message classes ***/
 #define STUN_CLASS_MASK                            0x0110  /* Bits C0,C1 */
@@ -146,64 +151,6 @@ extern "C" {
 #define STUN_ERROR_GLOBAL_FAIL               600
 
 
-/*** STUN decode helpers ***/
-
-#define STUN_MSG_ID_SIZE                 12
-
-#define STUN_MSG_MAX_REALM_LENGTH        128
-#define STUN_MSG_MAX_NONCE_LENGTH        128
-#define STUN_MSG_MAX_USERNAME_LENGTH     255
-#define STUN_MSG_MAX_PASSWORD_LENGTH     255
-#define STUN_MIN_CHANNEL_ID              0x4000
-#define STUN_MAX_CHANNEL_ID              0x7FFF
-
-#define IPV4_ADDR_LEN                    16
-#define IPV4_ADDR_LEN_WITH_PORT          (IPV4_ADDR_LEN + 6) /* Need extra space
-                                                              * for :port */
-#define IPV6_ADDR_LEN                    100
-
-#define STUN_REQ_TRANSPORT_UDP         (uint32_t)17 /* IANA protocol number */
-
-#define STUN_MIN_PACKET_SIZE             20
-#define STUN_HEADER_SIZE                 20
-#define STUN_MAX_PACKET_SIZE            1556
-#define STUN_MAX_ATTR_SIZE              1500
-#define STUN_MAX_STRING                 256
-#define STUN_MAX_UNKNOWN_ATTRIBUTES       8
-#define STUN_MAGIC_COOKIE_ARRAY         {0x21, 0x12, 0xA4, 0x42}
-#define STUN_MAGIC_COOKIE_SIZE          4
-#define STUN_PACKET_MASK                0xC0
-#define STUN_PACKET                     0x00
-#define TURN_CHANNEL_PACKET             0x40
-#define STUN_STRING_ALLIGNMENT          4
-
-#define STUNCLIENT_MAX_RETRANSMITS          9
-#define STUNCLIENT_RETRANSMIT_TIMEOUT_LIST      100, 200, 300, 400, 500, 500, \
-  500, 500, 500                                                                              /*
-                                                                                              *
-                                                                                              *
-                                                                                              *
-                                                                                              *
-                                                                                              *
-                                                                                              *
-                                                                                              *msec
-                                                                                              **/
-#define STUNCLIENT_DFLT_TICK_TIMER_MS            50
-
-#define STUN_KEEPALIVE_TIMER_SEC    15
-
-#define TURN_SEND_IND_HDR_SIZE      36  /* fixed overhead when using  TURN send
-                                         * indication  */
-                                        /* hdr(20)+Cookie(8)+Vers(8)+Data(4) */
-#define TURN_INTEG_LEN              24  /* size of integrity attribute */
-#define TURN_CHANNEL_DATA_HDR_SIZE   4  /* overhead when using  TURN channel
-                                         * data     */
-
-#define STUN_MAX_PEER_ADDR          10 /* max no. of peer addresses supported
-                                        * (e.g. when encoding  CreatePermission)
-                                        **/
-
-#define STUN_DFLT_PAD ' '             /* default padding char */
 
 
 typedef enum

--- a/include/stunlib_config.h
+++ b/include/stunlib_config.h
@@ -68,5 +68,7 @@
 
 #define STUN_DFLT_PAD ' '             /* default padding char */
 
+#define STUN_MAX_TRANSACTIONS  60
+#define STUN_SOFTWARE_NAME "Cisco"
 
 #endif //STUNLIB_STUNLIB_CONFIG_H

--- a/include/stunlib_config.h
+++ b/include/stunlib_config.h
@@ -1,0 +1,72 @@
+/*
+ *  See license file
+ */
+
+#ifndef STUNLIB_STUNLIB_CONFIG_H
+#define STUNLIB_STUNLIB_CONFIG_H
+
+/*
+ * Various configuration options for STUN that can be changed
+ */
+
+/*** STUN decode helpers ***/
+
+#define STUN_MSG_ID_SIZE                 12
+
+#define STUN_MSG_MAX_REALM_LENGTH        128
+#define STUN_MSG_MAX_NONCE_LENGTH        128
+#define STUN_MSG_MAX_USERNAME_LENGTH     255
+#define STUN_MSG_MAX_PASSWORD_LENGTH     255
+#define STUN_MIN_CHANNEL_ID              0x4000
+#define STUN_MAX_CHANNEL_ID              0x7FFF
+
+#define IPV4_ADDR_LEN                    16
+#define IPV4_ADDR_LEN_WITH_PORT          (IPV4_ADDR_LEN + 6) /* Need extra space
+                                                              * for :port */
+#define IPV6_ADDR_LEN                    100
+
+#define STUN_REQ_TRANSPORT_UDP         (uint32_t)17 /* IANA protocol number */
+
+#define STUN_MIN_PACKET_SIZE             20
+#define STUN_HEADER_SIZE                 20
+#define STUN_MAX_PACKET_SIZE            1556
+#define STUN_MAX_ATTR_SIZE              1500
+#define STUN_MAX_STRING                 256
+#define STUN_MAX_UNKNOWN_ATTRIBUTES       8
+#define STUN_MAGIC_COOKIE_ARRAY         {0x21, 0x12, 0xA4, 0x42}
+#define STUN_MAGIC_COOKIE_SIZE          4
+#define STUN_PACKET_MASK                0xC0
+#define STUN_PACKET                     0x00
+#define TURN_CHANNEL_PACKET             0x40
+#define STUN_STRING_ALLIGNMENT          4
+
+#define STUNCLIENT_MAX_RETRANSMITS          9
+#define STUNCLIENT_RETRANSMIT_TIMEOUT_LIST      100, 200, 300, 400, 500, 500, \
+  500, 500, 500                                                                              /*
+                                                                                              *
+                                                                                              *
+                                                                                              *
+                                                                                              *
+                                                                                              *
+                                                                                              *
+                                                                                              *msec
+                                                                                              **/
+#define STUNCLIENT_DFLT_TICK_TIMER_MS            50
+
+#define STUN_KEEPALIVE_TIMER_SEC    15
+
+#define TURN_SEND_IND_HDR_SIZE      36  /* fixed overhead when using  TURN send
+                                         * indication  */
+/* hdr(20)+Cookie(8)+Vers(8)+Data(4) */
+#define TURN_INTEG_LEN              24  /* size of integrity attribute */
+#define TURN_CHANNEL_DATA_HDR_SIZE   4  /* overhead when using  TURN channel
+                                         * data     */
+
+#define STUN_MAX_PEER_ADDR          10 /* max no. of peer addresses supported
+                                        * (e.g. when encoding  CreatePermission)
+                                        **/
+
+#define STUN_DFLT_PAD ' '             /* default padding char */
+
+
+#endif //STUNLIB_STUNLIB_CONFIG_H

--- a/include/stuntrace.h
+++ b/include/stuntrace.h
@@ -79,11 +79,11 @@ struct hiutResult {
 
 bool
 isDstUnreachable(const int32_t   ICMPtype,
-                 const u_int16_t addrFamily);
+                 const uint16_t addrFamily);
 
 bool
 isTimeExceeded(const int32_t   ICMPtype,
-               const u_int16_t addrFamily);
+               const uint16_t addrFamily);
 
 int
 StunTrace_startTrace(STUN_CLIENT_DATA*      clientData,

--- a/src/stunclient.c
+++ b/src/stunclient.c
@@ -191,7 +191,7 @@ BuildStunBindReq(STUN_TRANSACTION_DATA* trans,
 
   if (trans->stunBindReq.addSoftware)
   {
-    stunlib_addSoftware(stunReqMsg, SoftwareVersionStr, STUN_DFLT_PAD);
+    stunlib_addSoftware(stunReqMsg, STUN_SOFTWARE_NAME, STUN_DFLT_PAD);
   }
 
   if (trans->stunBindReq.addTransCnt)
@@ -246,7 +246,7 @@ StunClient_Alloc(STUN_CLIENT_DATA** clientDataPtr)
 
   StunClient_clearStats(clientData);
 
-  for (int i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+  for (int i = 0; i < STUN_MAX_TRANSACTIONS; i++)
   {
     STUN_TRANSACTION_DATA* trans = &clientData->data[i];
     trans->inst   = i;
@@ -292,7 +292,7 @@ StunClient_HandleTick(STUN_CLIENT_DATA* clientData,
   }
 
   /* call fsm for each timer that has expired */
-  for (int i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+  for (int i = 0; i < STUN_MAX_TRANSACTIONS; i++)
   {
     STUN_TRANSACTION_DATA* trans = &clientData->data[i];
     if ( trans->inUse && TimerHasExpired(trans, TimerResMsec) )
@@ -392,7 +392,7 @@ StunClient_HandleIncResp(STUN_CLIENT_DATA*      clientData,
     return;
   }
 
-  for (int i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+  for (int i = 0; i < STUN_MAX_TRANSACTIONS; i++)
   {
     STUN_TRANSACTION_DATA* trans = &clientData->data[i];
     if ( trans->inUse &&
@@ -443,7 +443,7 @@ StunClient_HandleICMP(STUN_CLIENT_DATA*      clientData,
   if ( isTimeExceeded(ICMPtype, srcAddr->sa_family) ||
        isDstUnreachable(ICMPtype,srcAddr->sa_family) )
   {
-    for (int i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+    for (int i = 0; i < STUN_MAX_TRANSACTIONS; i++)
     {
       STUN_TRANSACTION_DATA* trans = &clientData->data[i];
       if ( trans->inUse &&
@@ -489,7 +489,7 @@ StunClient_cancelBindingTransaction(STUN_CLIENT_DATA* clientData,
     return STUNCLIENT_CTX_UNKNOWN;
   }
 
-  for (int i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+  for (int i = 0; i < STUN_MAX_TRANSACTIONS; i++)
   {
     STUN_TRANSACTION_DATA* trans = &clientData->data[i];
     if ( trans->inUse &&
@@ -553,7 +553,7 @@ AllocFreeInst(STUN_CLIENT_DATA* clientData,
   (void) payload;
   int i;
 
-  for (i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+  for (i = 0; i < STUN_MAX_TRANSACTIONS; i++)
   {
     STUN_TRANSACTION_DATA* trans = &clientData->data[i];
     if (!trans->inUse)
@@ -684,7 +684,7 @@ StunClientMain(STUN_CLIENT_DATA* clientData,
   /* if  context is already known, just call the  fsm */
   if (ctx != STUNCLIENT_CTX_UNKNOWN)
   {
-    if (ctx < MAX_STUN_TRANSACTIONS)
+    if (ctx < STUN_MAX_TRANSACTIONS)
     {
       StunClientFsm(&clientData->data[ctx], sig, payload);
     }
@@ -696,7 +696,7 @@ StunClientMain(STUN_CLIENT_DATA* clientData,
                 "<STUNCLIENT> sig: %s illegal context %d exceeds %d\n ",
                 StunsigToStr(sig),
                 ctx,
-                MAX_STUN_TRANSACTIONS);
+                STUN_MAX_TRANSACTIONS);
     }
   }
   else if (sig == STUN_SIGNAL_BindReq)
@@ -1377,7 +1377,7 @@ StunClient_clearStats(STUN_CLIENT_DATA* clientData)
 
   memset(&clientData->stats, 0, sizeof clientData->stats);
 
-  for (int i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+  for (int i = 0; i < STUN_MAX_TRANSACTIONS; i++)
   {
     memset( &clientData->data[i].stats, 0, sizeof (struct StunClientStats) );
   }
@@ -1410,7 +1410,7 @@ StunClient_dumpStats (STUN_CLIENT_DATA*  clientData,
   stats.Retransmits                  += ptr->Retransmits;
   stats.Failures                     += ptr->Failures;
 
-  for (int i = 0; i < MAX_STUN_TRANSACTIONS; i++)
+  for (int i = 0; i < STUN_MAX_TRANSACTIONS; i++)
   {
     ptr = &clientData->data[i].stats;
 

--- a/src/stuntrace.c
+++ b/src/stuntrace.c
@@ -14,7 +14,7 @@ StunStatusCallBack(void*               userCtx,
 
 bool
 isDstUnreachable(const int32_t   ICMPtype,
-                 const u_int16_t addrFamily)
+                 const uint16_t addrFamily)
 {
   if ( ( (ICMPtype == 3) && (addrFamily == AF_INET) )  ||
        ( (ICMPtype == 1) && (addrFamily == AF_INET6) ) )
@@ -26,7 +26,7 @@ isDstUnreachable(const int32_t   ICMPtype,
 
 bool
 isTimeExceeded(const int32_t   ICMPtype,
-               const u_int16_t addrFamily)
+               const uint16_t addrFamily)
 {
   if ( ( (ICMPtype == 11) && (addrFamily == AF_INET) )  ||
        ( (ICMPtype == 3) && (addrFamily == AF_INET6) ) )


### PR DESCRIPTION
Some restructuring of the code to make it easier to override some of the definitions (especially statically allocated sizes for strings etc.).

This is achieved by optionally specifying a STUNLIB_CUSTOM_CONFIG preprocessor flag, i.e. `-D STUNLIB_CUSTOM_CONFIG="\"my_config.h\""` which gets included instead of the default one. Would like to hear your thoughts on this approach. A potential alternative might be something like:

```
#ifdef STUNLIB_CUSTOM_CONFIG
#include "stunlib_config_custom.h"
#else
#include "stunlib_config.h"
#endif
```

Also, changed u_int16_t to uint16_t for better compatibility, hope you don't mind.

On a positive note, this now happily runs on a esp32 SoC with 400kb of memory ;-)